### PR TITLE
Feature/tec 68 refactor the delete sprint functionality on the backlog page

### DIFF
--- a/src/api/ticket/ticket.ts
+++ b/src/api/ticket/ticket.ts
@@ -57,7 +57,10 @@ export function updateTicket(id: string, data: any) {
 }
 
 export function updateTicketSprint(ticketId: string, sprintId?: string | null, data?: any) {
-  return alphaApiV2.put(`${config.apiAddressV2}/tickets/${ticketId}`, { sprintId, ...data });
+  return alphaApiV2.put(`${config.apiAddressV2}/tickets/${ticketId}`, {
+    sprint: sprintId,
+    ...data
+  });
 }
 
 export function updateTicketEpic(ticketId: string, epic?: string | null) {

--- a/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.module.scss
+++ b/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.module.scss
@@ -10,22 +10,28 @@ $colorGreen: rgb(122, 184, 79);
 
 .moveIncompleteTicketsModal {
   min-width: 40%;
-  height: 40%;
-}
 
-.btnContainer {
-  width: 100%;
-  height: 40px;
   display: flex;
-  justify-content: center;
-  gap: 10px;  
-  .btn {
-    height: 100%;
-    border-radius: 5px;
-    width: 30%;
-    cursor: pointer;
-    border: none;
-    color: white;
-    background-color: $primaryColor;
+  flex-direction: column;
+
+  .btnContainer {
+    align-self: center;
+    max-width: 300px;
+    width: 100%;
+    height: 60px;
+    display: flex;
+    margin: 30px 0;
+    justify-content: center;
+    gap: 30px;  
+    .btn {
+      height: 100%;
+      border-radius: 5px;
+      width: 50%;
+      cursor: pointer;
+      border: none;
+      color: white;
+      background-color: $primaryColor;
+    }
   }
 }
+

--- a/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.module.scss
+++ b/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.module.scss
@@ -1,12 +1,4 @@
 @import '../../../../variables.scss';
-$closeBtnColor: rgb(202, 207, 227);
-$closeBtnColorHover: rgb(178, 182, 200);
-$colorGray: rgb(102, 106, 133);
-$colorBlue: rgb(50, 115, 246);
-$darkGray: rgb(240, 240, 240);
-$lightGray: rgb(250, 251, 252);
-$colorRed: rgb(234, 51, 35);
-$colorGreen: rgb(122, 184, 79);
 
 .moveIncompleteTicketsModal {
   min-width: 40%;

--- a/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.module.scss
+++ b/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.module.scss
@@ -1,0 +1,31 @@
+@import '../../../../variables.scss';
+$closeBtnColor: rgb(202, 207, 227);
+$closeBtnColorHover: rgb(178, 182, 200);
+$colorGray: rgb(102, 106, 133);
+$colorBlue: rgb(50, 115, 246);
+$darkGray: rgb(240, 240, 240);
+$lightGray: rgb(250, 251, 252);
+$colorRed: rgb(234, 51, 35);
+$colorGreen: rgb(122, 184, 79);
+
+.moveIncompleteTicketsModal {
+  min-width: 40%;
+  height: 40%;
+}
+
+.btnContainer {
+  width: 100%;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;  
+  .btn {
+    height: 100%;
+    border-radius: 5px;
+    width: 30%;
+    cursor: pointer;
+    border: none;
+    color: white;
+    background-color: $primaryColor;
+  }
+}

--- a/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.tsx
+++ b/src/pages/BacklogPage/components/MoveIncompleteTicketsModal/MoveIncompleteTicketsModal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Modal from '../../../../lib/Modal/Modal';
+import DefaultModalHeader from '../../../../lib/Modal/ModalHeader/DefaultModalHeader/DefaultModalHeader';
+import styles from './MoveIncompleteTicketsModal.module.scss';
+
+interface MoveIncompleteTicketsModalProps {
+  onConfirm: (target: 'sprint' | 'backlog') => void;
+  onClickCloseModal: () => void;
+}
+
+export default function MoveIncompleteTicketsModal({
+  onConfirm,
+  onClickCloseModal
+}: Readonly<MoveIncompleteTicketsModalProps>) {
+  return (
+    <Modal classesName={styles.moveIncompleteTicketsModal}>
+      <DefaultModalHeader
+        title="Where do you want to move incomplete tickets?"
+        onClickClose={() => {
+          onClickCloseModal();
+        }}
+      />
+
+      <div className={styles.btnContainer}>
+        <button className={styles.btn} onClick={() => onConfirm('sprint')}>
+          To Next Sprint
+        </button>
+        <button className={styles.btn} onClick={() => onConfirm('backlog')}>
+          To Backlog
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/pages/BacklogPage/components/SprintSection/SprintSection.tsx
+++ b/src/pages/BacklogPage/components/SprintSection/SprintSection.tsx
@@ -17,6 +17,7 @@ import { Permission } from '../../../../utils/permission';
 interface ISprintSection {
   sprint: ISprint;
   totalIssue: number;
+  onSprintComplete: (sprintId: string) => Promise<boolean>;
   children?: React.ReactNode | string;
   dataTestId?: string;
 }
@@ -25,7 +26,8 @@ export default function SprintSection({
   totalIssue,
   sprint,
   dataTestId,
-  children
+  children,
+  onSprintComplete
 }: ISprintSection) {
   const { projectId = '' } = useParams();
   const projectDetails = useContext(ProjectDetailsContext);
@@ -49,7 +51,10 @@ export default function SprintSection({
         toast.error('Temporary Server Error. Try Again.', { theme: 'colored' });
       });
   };
-  const onClickCompleteSprint = (sprintId: string) => {
+  const onClickCompleteSprint = async (sprintId: string) => {
+    const isSuccess = await onSprintComplete(sprintId);
+    if (!isSuccess) return;
+
     const data = { isComplete: true, currentSprint: false };
     updateSprint(sprintId, data)
       .then((res) => {


### PR DESCRIPTION
### This pr refactors the complete sprint functionality on the backlog page
- Created logic to move **incomplete tickets** (tickets not in `done` status)
  - Move to the next closest sprint
  - Move to backlog
  - Click ❌ to abort sprint completion
- Add confirmation UI

### Demo videos:
https://github.com/user-attachments/assets/ec5ae0ec-db12-410d-b760-fda9dd5bfcde

